### PR TITLE
fixed bug with battery not starting automatically after depletion

### DIFF
--- a/Assets/Scripts/UI-Scripts/BatteryTimerController.cs
+++ b/Assets/Scripts/UI-Scripts/BatteryTimerController.cs
@@ -76,6 +76,7 @@ public class BatteryTimerController : MonoBehaviour {
         {
             //Set new timeStart
             timeStart = Time.time;
+            Time.timeScale = 1;
             batteryPrecentage = 100;
             runTimer = true;
         }


### PR DESCRIPTION
sets the timescale to 1 in first call to timestart. Fixes bug where timescale sometimes would be 0 (probably due to how remaining events are fired on nextDay() call)