### PR TITLE
Updated validation method. Now longer give duplicate minus points for…

### DIFF
--- a/Assets/Prefabs/InformationTaskItemPanel.prefab
+++ b/Assets/Prefabs/InformationTaskItemPanel.prefab
@@ -138,7 +138,7 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 24
+    m_FontSize: 20
     m_FontStyle: 0
     m_BestFit: 0
     m_MinSize: 0

--- a/Assets/Prefabs/Managers/GameManager.prefab
+++ b/Assets/Prefabs/Managers/GameManager.prefab
@@ -53,8 +53,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   score: 0
   privateScore: 0
+  dayCount: 1
   turnCount: 0
-  endDay: 8
+  endDay: 3
   playerCharacterScriptableObject: {fileID: 11400000, guid: ca6dafac2c5e4f445aca25eb2e282685,
     type: 2}
   playerCharacter: {fileID: 11400000, guid: ca6dafac2c5e4f445aca25eb2e282685, type: 2}
@@ -62,12 +63,22 @@ MonoBehaviour:
     type: 2}
   characterList: []
   objectivesList:
-  - description: Where does tom Live?
+  - description: What is the full name of everyone in your friendlist?
     tasks:
-    - 'Street of Ficton 79, 394 New State Fantasy, Wonderland '
-  - description: Where does Trine Live?
+    - Tom Hansen
+    - Trine Johnson
+    - Hank Rudy
+    - Hugo Seingrass
+    - Sara Scoffield
+    - Marie Bradley
+  - description: What is the adress of Tom and Trine? And what did your mother post
+      on friendsbook on her birthday?
     tasks:
     - Sci-fi Street 12, 540 Atlantis Space Farm, North Mars Colony
+    - Street of Ficton 79, 394 New State Fantasy, Wonderland
+    - Im so glad to be 50 years old. I know i'm getting old, but you know what keeps
+      me up and going? My children. They're the best thing that ever happened to me,
+      and I'm so proud of them. Thanks for all birthday wishes!
   informationPackageManager: {fileID: 0}
   backupRequirementDict: {fileID: 0}
   requirementDict:

--- a/Assets/Prefabs/Windows/Phone/PhonePrefab.prefab
+++ b/Assets/Prefabs/Windows/Phone/PhonePrefab.prefab
@@ -373,6 +373,25 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1619604754685138
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224197263008623016}
+  - component: {fileID: 222487445620047838}
+  - component: {fileID: 114038017234238688}
+  - component: {fileID: 114042929211260688}
+  - component: {fileID: 114617308006869118}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1 &1649543296496840
 GameObject:
   m_ObjectHideFlags: 1
@@ -620,6 +639,58 @@ Animator:
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
+--- !u!114 &114038017234238688
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1619604754685138}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 20
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'Information package:'
+--- !u!114 &114042929211260688
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1619604754685138}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1679637790, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &114067575641137848
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1426,7 +1497,10 @@ MonoBehaviour:
   - {fileID: 21300000, guid: bf23d0c04bd43b24da2caf103bf6f146, type: 3}
   - {fileID: 21300000, guid: 5af76df0fdce15a43a16ab25a225502e, type: 3}
   - {fileID: 21300000, guid: e4df8b6aac05943448b5345a0ecaf432, type: 3}
-  eventBreakpoints: []
+  eventBreakpoints:
+  - 99
+  - 70
+  - 50
   text: {fileID: 114820503792575996}
   imageHolder: {fileID: 114410389454711174}
   runTimer: 0
@@ -1472,6 +1546,19 @@ MonoBehaviour:
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
+--- !u!114 &114617308006869118
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1619604754685138}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1741964061, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 0
 --- !u!114 &114622636331133214
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2080,8 +2167,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 114650894436766546}
   m_HandleRect: {fileID: 224400618774162426}
   m_Direction: 2
-  m_Value: 1
-  m_Size: 0.9999999
+  m_Value: 0
+  m_Size: 0.9999998
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -2190,6 +2277,12 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1594940955660482}
+--- !u!222 &222487445620047838
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1619604754685138}
 --- !u!222 &222570098313540126
 CanvasRenderer:
   m_ObjectHideFlags: 1
@@ -2311,7 +2404,7 @@ RectTransform:
   m_Children:
   - {fileID: 224960661732993656}
   m_Father: {fileID: 224223357404968482}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -2424,7 +2517,7 @@ RectTransform:
   - {fileID: 224779025663163398}
   - {fileID: 224222228841322836}
   m_Father: {fileID: 224223357404968482}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -2449,6 +2542,24 @@ RectTransform:
   m_AnchoredPosition: {x: 289.35, y: -55.9375}
   m_SizeDelta: {x: 568.7, y: 71.875}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224197263008623016
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1619604754685138}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 224223357404968482}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 5, y: -197.76547}
+  m_SizeDelta: {x: 176.54639, y: 30}
+  m_Pivot: {x: 0, y: 1}
 --- !u!224 &224222228841322836
 RectTransform:
   m_ObjectHideFlags: 1
@@ -2480,6 +2591,7 @@ RectTransform:
   m_Children:
   - {fileID: 224194376701215452}
   - {fileID: 224882961388449806}
+  - {fileID: 224197263008623016}
   - {fileID: 224182330143619768}
   - {fileID: 224750109705681010}
   - {fileID: 224078616079895498}
@@ -2581,7 +2693,7 @@ RectTransform:
   m_Father: {fileID: 224415250542438492}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.00000011920929}
+  m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
@@ -2790,7 +2902,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 224223357404968482}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -2849,7 +2961,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.000011130625, y: -0.000047310343}
+  m_AnchoredPosition: {x: -0.000011130625, y: 0.000029612525}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!224 &224882961388449806

--- a/Assets/Scenes/AppSettingsScene.unity
+++ b/Assets/Scenes/AppSettingsScene.unity
@@ -291,12 +291,12 @@ Prefab:
     - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
         type: 2}
       propertyPath: objectivesList.Array.data[0].tasks.Array.size
-      value: 1
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
         type: 2}
       propertyPath: objectivesList.Array.data[1].tasks.Array.size
-      value: 1
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 4394351200903840, guid: fe23e48f08a432a4fbadaece7414ddde, type: 2}
       propertyPath: m_LocalPosition.x
@@ -333,7 +333,7 @@ Prefab:
     - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
         type: 2}
       propertyPath: endDay
-      value: 8
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
         type: 2}
@@ -354,17 +354,18 @@ Prefab:
     - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
         type: 2}
       propertyPath: objectivesList.Array.data[0].description
-      value: Where does tom Live?
+      value: What is the full name of everyone in your friendlist?
       objectReference: {fileID: 0}
     - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
         type: 2}
       propertyPath: objectivesList.Array.data[0].tasks.Array.data[0]
-      value: 'Street of Ficton 79, 394 New State Fantasy, Wonderland '
+      value: Tom Hansen
       objectReference: {fileID: 0}
     - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
         type: 2}
       propertyPath: objectivesList.Array.data[1].description
-      value: Where does Trine Live?
+      value: What is the adress of Tom and Trine? And what did your mother post on
+        friendsbook on her birthday?
       objectReference: {fileID: 0}
     - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
         type: 2}
@@ -375,6 +376,43 @@ Prefab:
         type: 2}
       propertyPath: dayCount
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
+        type: 2}
+      propertyPath: objectivesList.Array.data[0].tasks.Array.data[1]
+      value: Trine Johnson
+      objectReference: {fileID: 0}
+    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
+        type: 2}
+      propertyPath: objectivesList.Array.data[0].tasks.Array.data[2]
+      value: Hank Rudy
+      objectReference: {fileID: 0}
+    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
+        type: 2}
+      propertyPath: objectivesList.Array.data[0].tasks.Array.data[3]
+      value: Hugo Seingrass
+      objectReference: {fileID: 0}
+    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
+        type: 2}
+      propertyPath: objectivesList.Array.data[0].tasks.Array.data[4]
+      value: Sara Scoffield
+      objectReference: {fileID: 0}
+    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
+        type: 2}
+      propertyPath: objectivesList.Array.data[0].tasks.Array.data[5]
+      value: Marie Bradley
+      objectReference: {fileID: 0}
+    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
+        type: 2}
+      propertyPath: objectivesList.Array.data[1].tasks.Array.data[1]
+      value: Street of Ficton 79, 394 New State Fantasy, Wonderland
+      objectReference: {fileID: 0}
+    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
+        type: 2}
+      propertyPath: objectivesList.Array.data[1].tasks.Array.data[2]
+      value: Im so glad to be 50 years old. I know i'm getting old, but you know what
+        keeps me up and going? My children. They're the best thing that ever happened
+        to me, and I'm so proud of them. Thanks for all birthday wishes!
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: fe23e48f08a432a4fbadaece7414ddde, type: 2}

--- a/Assets/Scenes/Days/Day1.unity
+++ b/Assets/Scenes/Days/Day1.unity
@@ -577,12 +577,12 @@ Prefab:
     - target: {fileID: 224470795190957040, guid: 0df9167830bae3c479311063872cc94b,
         type: 2}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 131.14754
       objectReference: {fileID: 0}
     - target: {fileID: 224470795190957040, guid: 0df9167830bae3c479311063872cc94b,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 54.644806
       objectReference: {fileID: 0}
     - target: {fileID: 224069702574487742, guid: 0df9167830bae3c479311063872cc94b,
         type: 2}
@@ -716,7 +716,7 @@ Prefab:
     - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
         type: 2}
       propertyPath: objectivesList.Array.size
-      value: 4
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
         type: 2}

--- a/Assets/Scenes/Days/Day1.unity
+++ b/Assets/Scenes/Days/Day1.unity
@@ -577,12 +577,12 @@ Prefab:
     - target: {fileID: 224470795190957040, guid: 0df9167830bae3c479311063872cc94b,
         type: 2}
       propertyPath: m_SizeDelta.x
-      value: 131.14754
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224470795190957040, guid: 0df9167830bae3c479311063872cc94b,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 54.644806
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224069702574487742, guid: 0df9167830bae3c479311063872cc94b,
         type: 2}
@@ -713,31 +713,6 @@ Prefab:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
-        type: 2}
-      propertyPath: objectivesList.Array.size
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
-        type: 2}
-      propertyPath: objectivesList.Array.data[0].tasks.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
-        type: 2}
-      propertyPath: objectivesList.Array.data[1].tasks.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
-        type: 2}
-      propertyPath: objectivesList.Array.data[2].tasks.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
-        type: 2}
-      propertyPath: objectivesList.Array.data[3].tasks.Array.size
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 4394351200903840, guid: fe23e48f08a432a4fbadaece7414ddde, type: 2}
       propertyPath: m_LocalPosition.x
       value: 434.2009
@@ -772,60 +747,10 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
         type: 2}
-      propertyPath: informationPackageManager
-      value: 
-      objectReference: {fileID: 1915597265}
-    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
-        type: 2}
-      propertyPath: objectivesList.Array.data[0].description
-      value: Where does Tom Live?
-      objectReference: {fileID: 0}
-    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
-        type: 2}
-      propertyPath: objectivesList.Array.data[0].tasks.Array.data[0]
-      value: 'Street of Ficton 79, 394 New State Fantasy, Wonderland '
-      objectReference: {fileID: 0}
-    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
-        type: 2}
-      propertyPath: objectivesList.Array.data[1].description
-      value: z
-      objectReference: {fileID: 0}
-    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
-        type: 2}
-      propertyPath: objectivesList.Array.data[1].tasks.Array.data[0]
-      value: 'Street of Ficton 79, 394 New State Fantasy, Wonderland '
-      objectReference: {fileID: 0}
-    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
-        type: 2}
-      propertyPath: objectivesList.Array.data[2].description
-      value: Does Tom Hansen Lives?
-      objectReference: {fileID: 0}
-    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
-        type: 2}
-      propertyPath: objectivesList.Array.data[2].tasks.Array.data[0]
-      value: 'Street of Ficton 79, 394 New State Fantasy, Wonderland '
-      objectReference: {fileID: 0}
-    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
-        type: 2}
-      propertyPath: dayCount
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
-        type: 2}
       propertyPath: backupRequirementDict
       value: 
       objectReference: {fileID: 11400000, guid: 852e4bb7e3018f043985048db18f4f38,
         type: 2}
-    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
-        type: 2}
-      propertyPath: objectivesList.Array.data[3].description
-      value: Does Tom Hansen Live?
-      objectReference: {fileID: 0}
-    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
-        type: 2}
-      propertyPath: objectivesList.Array.data[3].tasks.Array.data[0]
-      value: 'Street of Ficton 79, 394 New State Fantasy, Wonderland '
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: fe23e48f08a432a4fbadaece7414ddde, type: 2}
   m_IsPrefabParent: 0
@@ -835,12 +760,6 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 417585809}
   m_Script: {fileID: 11500000, guid: de2d9e27bc5c49747bbe8e954d102700, type: 3}
---- !u!114 &1915597265 stripped
-MonoBehaviour:
-  m_PrefabParentObject: {fileID: 114269145749341886, guid: 10d12701ad09b1946a4ec07283c144d1,
-    type: 2}
-  m_PrefabInternal: {fileID: 77616380}
-  m_Script: {fileID: 11500000, guid: 2dc3892055d4e481095e96036db246a6, type: 3}
 --- !u!224 &1975755456 stripped
 RectTransform:
   m_PrefabParentObject: {fileID: 224740445323244564, guid: 0df9167830bae3c479311063872cc94b,

--- a/Assets/Scenes/Days/Day2.unity
+++ b/Assets/Scenes/Days/Day2.unity
@@ -835,7 +835,7 @@ Prefab:
     - target: {fileID: 224470795190957040, guid: 0df9167830bae3c479311063872cc94b,
         type: 2}
       propertyPath: m_SizeDelta.x
-      value: 131.14754
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224470795190957040, guid: 0df9167830bae3c479311063872cc94b,
         type: 2}
@@ -881,6 +881,11 @@ Prefab:
         type: 2}
       propertyPath: eventBreakpoints.Array.data[2]
       value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 114588024711813310, guid: 0df9167830bae3c479311063872cc94b,
+        type: 2}
+      propertyPath: timeLenght
+      value: 40
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 0df9167830bae3c479311063872cc94b, type: 2}

--- a/Assets/Scenes/Days/Day2.unity
+++ b/Assets/Scenes/Days/Day2.unity
@@ -591,6 +591,16 @@ Prefab:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
+        type: 2}
+      propertyPath: objectivesList.Array.data[0].tasks.Array.size
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
+        type: 2}
+      propertyPath: objectivesList.Array.data[1].tasks.Array.size
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 4394351200903840, guid: fe23e48f08a432a4fbadaece7414ddde, type: 2}
       propertyPath: m_LocalPosition.x
       value: 434.2009
@@ -638,6 +648,59 @@ Prefab:
         type: 2}
       propertyPath: dayCount
       value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
+        type: 2}
+      propertyPath: objectivesList.Array.data[0].description
+      value: What is the full name of everyone in your friendlist?
+      objectReference: {fileID: 0}
+    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
+        type: 2}
+      propertyPath: objectivesList.Array.data[0].tasks.Array.data[1]
+      value: Tom Hansen
+      objectReference: {fileID: 0}
+    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
+        type: 2}
+      propertyPath: objectivesList.Array.data[0].tasks.Array.data[2]
+      value: Trine Johnson
+      objectReference: {fileID: 0}
+    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
+        type: 2}
+      propertyPath: objectivesList.Array.data[0].tasks.Array.data[3]
+      value: Sara Scoffield
+      objectReference: {fileID: 0}
+    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
+        type: 2}
+      propertyPath: objectivesList.Array.data[0].tasks.Array.data[4]
+      value: Hugo Seingrass
+      objectReference: {fileID: 0}
+    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
+        type: 2}
+      propertyPath: objectivesList.Array.data[0].tasks.Array.data[5]
+      value: Hank Rudy
+      objectReference: {fileID: 0}
+    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
+        type: 2}
+      propertyPath: objectivesList.Array.data[0].tasks.Array.data[0]
+      value: Marie Bradley
+      objectReference: {fileID: 0}
+    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
+        type: 2}
+      propertyPath: objectivesList.Array.data[1].description
+      value: What is the adress of Tom and Trine? And what did your mother post on
+        friendsbook on her birthday?
+      objectReference: {fileID: 0}
+    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
+        type: 2}
+      propertyPath: objectivesList.Array.data[1].tasks.Array.data[1]
+      value: Street of Ficton 79, 394 New State Fantasy, Wonderland
+      objectReference: {fileID: 0}
+    - target: {fileID: 114064215573790780, guid: fe23e48f08a432a4fbadaece7414ddde,
+        type: 2}
+      propertyPath: objectivesList.Array.data[1].tasks.Array.data[2]
+      value: Im so glad to be 50 years old. I know i'm getting old, but you know what
+        keeps me up and going? My children. They're the best thing that ever happened
+        to me, and I'm so proud of them. Thanks for all birthday wishes!
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: fe23e48f08a432a4fbadaece7414ddde, type: 2}
@@ -772,7 +835,7 @@ Prefab:
     - target: {fileID: 224470795190957040, guid: 0df9167830bae3c479311063872cc94b,
         type: 2}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 131.14754
       objectReference: {fileID: 0}
     - target: {fileID: 224470795190957040, guid: 0df9167830bae3c479311063872cc94b,
         type: 2}

--- a/Assets/Scripts/Classes/DigitalInvestigator/InformationPackageManager.cs
+++ b/Assets/Scripts/Classes/DigitalInvestigator/InformationPackageManager.cs
@@ -43,6 +43,7 @@ public class InformationPackageManager : MonoBehaviour {
                             {
                                 if (taskmatch == false)
                                 {
+                                    // DEBUGGING START
                                     // DEBUGGING FOR SPECIAL ANNOYING STRING THAT WONT MATCH (mother post task on day 2)
                                     string x = "Im so glad to be 50 years old. I know i'm getting old, but you know what keeps me up and going? My children. They're the best thing that ever happened to me, and I'm so proud of them. Thanks for all birthday wishes!";
                                     if (o.tasks[j].Equals(x))
@@ -57,6 +58,7 @@ public class InformationPackageManager : MonoBehaviour {
                                     {
                                         Debug.Log("temp compares to x");
                                     }
+                                    // DEBUGGING END
                                     if (o.tasks[j].Equals(temp) || temp.Contains(o.tasks[j]))
                                     {
                                         taskmatch = true;

--- a/Assets/Scripts/Classes/DigitalInvestigator/InformationPackageManager.cs
+++ b/Assets/Scripts/Classes/DigitalInvestigator/InformationPackageManager.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Text.RegularExpressions;
 using UnityEngine;
 
 public class InformationPackageManager : MonoBehaviour {
@@ -38,26 +39,26 @@ public class InformationPackageManager : MonoBehaviour {
                         for (int i = 0; i < informationPackage.Count; i += 2)
                         {
                             bool taskmatch = false;
-                            string temp = informationPackage[i + 1];
+                            string temp = Regex.Replace(informationPackage[i + 1], @"\n", " "); //newlines are added by Text component. This removes them
                             for(int j = 0; j < o.tasks.Count;j++)
                             {
                                 if (taskmatch == false)
                                 {
                                     // DEBUGGING START
                                     // DEBUGGING FOR SPECIAL ANNOYING STRING THAT WONT MATCH (mother post task on day 2)
-                                    string x = "Im so glad to be 50 years old. I know i'm getting old, but you know what keeps me up and going? My children. They're the best thing that ever happened to me, and I'm so proud of them. Thanks for all birthday wishes!";
-                                    if (o.tasks[j].Equals(x))
-                                    {
-                                        Debug.Log(temp.Length);
-                                        string newString = temp.Replace("\n","").Replace("\r","");
-                                        Debug.Log(o.tasks[j].Equals(newString));
-                                        Debug.Log(o.tasks[j].Length);
-                                        Debug.Log("tasks compare to x");
-                                    }
-                                    if (temp.Equals(x))
-                                    {
-                                        Debug.Log("temp compares to x");
-                                    }
+                                    //string x = "Im so glad to be 50 years old. I know i'm getting old, but you know what keeps me up and going? My children. They're the best thing that ever happened to me, and I'm so proud of them. Thanks for all birthday wishes!";
+                                    //if (o.tasks[j].Equals(x))
+                                    //{
+                                    //    Debug.Log(temp.Length);
+                                    //    string newString = temp.Replace("\n","").Replace("\r","");
+                                    //    Debug.Log(o.tasks[j].Equals(newString));
+                                    //    Debug.Log(o.tasks[j].Length);
+                                    //    Debug.Log("tasks compare to x");
+                                    //}
+                                    //if (temp.Equals(x))
+                                    //{
+                                    //    Debug.Log("temp compares to x");
+                                    //}
                                     // DEBUGGING END
                                     if (o.tasks[j].Equals(temp) || temp.Contains(o.tasks[j]))
                                     {
@@ -73,7 +74,7 @@ public class InformationPackageManager : MonoBehaviour {
                             }
                             if (taskmatch == false)
                             {
-                                Debug.Log("This one is not a match: " + temp);
+                                //Debug.Log("This one is not a match: " + temp);
                                 minusScore -= 10;
                             }
                             else
@@ -90,6 +91,8 @@ public class InformationPackageManager : MonoBehaviour {
                     }
                 }
             }
+            Debug.Log("Plusscore: " + plusScore);
+            Debug.Log("minusscore: " + minusScore);
             gameManager.AddToScore(plusScore);
             gameManager.AddToScore(minusScore);
         }

--- a/Assets/Scripts/Classes/DigitalInvestigator/InformationPackageManager.cs
+++ b/Assets/Scripts/Classes/DigitalInvestigator/InformationPackageManager.cs
@@ -1,18 +1,20 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using UnityEngine;
 
 public class InformationPackageManager : MonoBehaviour {
 
 	private GameManager gameManager;
 	private Dictionary<int, List<Objective>> objectives;
-	private Dictionary<int, List<string>> informationPackage;
+	private List<string> informationPackage;
 	public int dayCount = 0;
 
 	void Start() {
 		gameManager = GameObject.Find("GameManager").GetComponent<GameManager>();
 		objectives = gameManager.objectives; // = gm.objectivesDict <int, List<Objective>>
-        informationPackage = gameManager.informationDict; // gm._informationDict <int, List<string>>
+        informationPackage = gameManager.informationPackage; 
         dayCount = gameManager.GetDayCount();
 	}
 
@@ -22,41 +24,76 @@ public class InformationPackageManager : MonoBehaviour {
 	// Sorry in advance ...
 	public void ValidateInformationGathered() {
 		dayCount = gameManager.GetDayCount();
+        int minusScore = 0;
+        int plusScore = 0;
+        int informationCount = informationPackage.Count / 2;
         if (informationPackage != null)
         {
-            foreach (KeyValuePair<int, List<string>> info in informationPackage)
+            foreach (KeyValuePair<int, List<Objective>> obj in objectives)
             {
-                if (info.Key == dayCount)
+                if (obj.Key == dayCount)
                 {
-                    for (int i =0 ; i < info.Value.Count; i += 2)
+                    foreach (Objective o in obj.Value)
                     {
-                        string temp = info.Value[i];
-                        foreach (KeyValuePair<int, List<Objective>> obj in objectives)
+                        for (int i = 0; i < informationPackage.Count; i += 2)
                         {
-                            if (obj.Key == dayCount)
+                            bool taskmatch = false;
+                            string temp = informationPackage[i + 1];
+                            for(int j = 0; j < o.tasks.Count;j++)
                             {
-                                foreach (Objective o in obj.Value)
+                                if (taskmatch == false)
                                 {
-                                    foreach (string task in o.tasks)
+                                    // DEBUGGING FOR SPECIAL ANNOYING STRING THAT WONT MATCH (mother post task on day 2)
+                                    string x = "Im so glad to be 50 years old. I know i'm getting old, but you know what keeps me up and going? My children. They're the best thing that ever happened to me, and I'm so proud of them. Thanks for all birthday wishes!";
+                                    if (o.tasks[j].Equals(x))
                                     {
-                                        if (task.Equals(temp) || temp.Contains(task))
-                                        {
-                                            gameManager.AddToScore(20);
-                                        }
-                                        else
-                                        {
-                                            gameManager.AddToScore(-5);
-                                        }
+                                        Debug.Log(temp.Length);
+                                        string newString = temp.Replace("\n","").Replace("\r","");
+                                        Debug.Log(o.tasks[j].Equals(newString));
+                                        Debug.Log(o.tasks[j].Length);
+                                        Debug.Log("tasks compare to x");
+                                    }
+                                    if (temp.Equals(x))
+                                    {
+                                        Debug.Log("temp compares to x");
+                                    }
+                                    if (o.tasks[j].Equals(temp) || temp.Contains(o.tasks[j]))
+                                    {
+                                        taskmatch = true;
+                                        break;
                                     }
                                 }
+                                else
+                                {
+                                    break;
+                                }
+
+                            }
+                            if (taskmatch == false)
+                            {
+                                Debug.Log("This one is not a match: " + temp);
+                                minusScore -= 10;
+                            }
+                            else
+                            {
+                                plusScore += 50;
                             }
                         }
+                        if (informationCount < o.tasks.Count)
+                        {
+                            int difference = (o.tasks.Count - informationCount) * 10;
+                            minusScore -= difference;
+                        }
+                       
                     }
                 }
             }
+            gameManager.AddToScore(plusScore);
+            gameManager.AddToScore(minusScore);
         }
         else
         {
+            Debug.Log("Information package is null, gving -25 penalty to score..");
             gameManager.AddToScore(-25);
         }
 		

--- a/Assets/Scripts/Classes/Friendsbook/View/FriendsbookAboutView.cs
+++ b/Assets/Scripts/Classes/Friendsbook/View/FriendsbookAboutView.cs
@@ -35,7 +35,7 @@ public class FriendsbookAboutView : MonoBehaviour {
     {
         if (!nameText.text.Equals("NA") && !currentDay.Contains(nameText.text))
         {
-            currentDay.Add("Information");
+            currentDay.Add("Information:");
             currentDay.Add(nameText.text);
         }
     }
@@ -44,7 +44,7 @@ public class FriendsbookAboutView : MonoBehaviour {
     {
         if (!addressText.text.Equals("NA") && !currentDay.Contains(addressText.text))
         {
-            currentDay.Add("Information");
+            currentDay.Add("Information:");
             currentDay.Add(addressText.text);
         }
     }
@@ -53,7 +53,7 @@ public class FriendsbookAboutView : MonoBehaviour {
     {
         if (!emailText.text.Equals("NA") && !currentDay.Contains(emailText.text))
         {
-            currentDay.Add("Information");
+            currentDay.Add("Information:");
             currentDay.Add(emailText.text);
         }
     }
@@ -62,7 +62,7 @@ public class FriendsbookAboutView : MonoBehaviour {
     {
         if (!phoneNumberText.text.Equals("NA") && !currentDay.Contains(phoneNumberText.text))
         {
-            currentDay.Add("Information");
+            currentDay.Add("Information:");
             currentDay.Add(phoneNumberText.text);
         }
     }

--- a/Assets/Scripts/Classes/Friendsbook/View/PostView.cs
+++ b/Assets/Scripts/Classes/Friendsbook/View/PostView.cs
@@ -35,7 +35,7 @@ public class PostView : MonoBehaviour {
         if(!currentDay.Contains(content.text) && !content.text.Equals(""))
         {
             currentDay.Add("Posts");
-            currentDay.Add(content.text);
+            currentDay.Add(content.text.ToString());
         }
     }
 }

--- a/Assets/Scripts/Classes/Friendsbook/View/PostView.cs
+++ b/Assets/Scripts/Classes/Friendsbook/View/PostView.cs
@@ -34,7 +34,7 @@ public class PostView : MonoBehaviour {
     {
         if(!currentDay.Contains(content.text) && !content.text.Equals(""))
         {
-            currentDay.Add("Posts");
+            currentDay.Add("Post:");
             currentDay.Add(content.text.ToString());
         }
     }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -51,10 +51,10 @@ public class GameManager : MonoBehaviour {
     private GameState _gameState;
 
     //gameState property. Publishes event on change
-    private GameState gameState
+    public GameState gameState
     {
         get { return _gameState; }
-        set
+        private set
         {
             if (_gameState != value)
             {

--- a/Assets/Scripts/UI-Scripts/DropDownItemController.cs
+++ b/Assets/Scripts/UI-Scripts/DropDownItemController.cs
@@ -105,7 +105,7 @@ public class DropDownItemController : MonoBehaviour {
         foreach (Dropdown d in GameObject.FindObjectsOfType<Dropdown>()) {
             Transform text = d.transform.parent.GetChild(1);
             if (text.name.Contains("NameText")) {
-                Requirement temp = new Requirement(text.GetComponent<Text>().text);
+                Requirement temp = new Requirement("Facebook");
                 if (d.value == 1)
                 {
                     gm.requirements.Add(temp.requirementName, Setting.Public);

--- a/Assets/Scripts/UI-Scripts/NotificationBar.cs
+++ b/Assets/Scripts/UI-Scripts/NotificationBar.cs
@@ -18,6 +18,7 @@ public class NotificationBar : MonoBehaviour, IPointerClickHandler
     private StringSettingDictionary settingsList;
     private Requirement requirement;
     private List<string> informationPackage;
+    private Button submitButton; //reference to submitbutton
 
 
     public GameObject scrollView;
@@ -34,6 +35,7 @@ public class NotificationBar : MonoBehaviour, IPointerClickHandler
         informationPackage = GameManager.Instance.informationPackage;
         objectivesList = GameManager.Instance.objectives;
         stats.text = "Score: " + gameManager.score.ToString();
+        submitButton = dropDown.transform.Find("SubmitButton").GetComponent<Button>();
 
         informationPackageListItemsColor2 = new Color(0.8f, 0.8f, 0.8f, 1);
         informationPackageListItemsColor1 = new Color(1, 1, 1, 1);
@@ -82,6 +84,10 @@ public class NotificationBar : MonoBehaviour, IPointerClickHandler
     //Opens dropdown
     public void OnPointerClick(PointerEventData eventData)
     {
+        //set interactable of submit button based on gamestate
+        if(gameManager.gameState != GameState.investigator) { submitButton.interactable = false; }
+        else { submitButton.interactable = true; }
+
         //Sets score string
         stats.text = "Score: " + gameManager.score;
 

--- a/Assets/Scripts/UI-Scripts/NotificationBar.cs
+++ b/Assets/Scripts/UI-Scripts/NotificationBar.cs
@@ -58,6 +58,11 @@ public class NotificationBar : MonoBehaviour, IPointerClickHandler
         if(args.newState == GameState.investigator)
         {
             stats.text = "Score: " + gameManager.score.ToString();
+            submitButton.interactable = true; //only allow submit while in investigator
+        }
+        else
+        {
+            submitButton.interactable = false;
         }
     }
 
@@ -84,9 +89,6 @@ public class NotificationBar : MonoBehaviour, IPointerClickHandler
     //Opens dropdown
     public void OnPointerClick(PointerEventData eventData)
     {
-        //set interactable of submit button based on gamestate
-        if(gameManager.gameState != GameState.investigator) { submitButton.interactable = false; }
-        else { submitButton.interactable = true; }
 
         //Sets score string
         stats.text = "Score: " + gameManager.score;

--- a/Assets/Scripts/UI-Scripts/NotificationBar.cs
+++ b/Assets/Scripts/UI-Scripts/NotificationBar.cs
@@ -24,12 +24,19 @@ public class NotificationBar : MonoBehaviour, IPointerClickHandler
     public GameObject dropDown;
     private GameManager gameManager;
 
+    //colors used to differentiate list items in information package
+    private Color informationPackageListItemsColor1;
+    private Color informationPackageListItemsColor2;
+
     void Start()
     {
         settingsList = GameManager.Instance.requirements;
         informationPackage = GameManager.Instance.informationPackage;
         objectivesList = GameManager.Instance.objectives;
         stats.text = "Score: " + gameManager.score.ToString();
+
+        informationPackageListItemsColor2 = new Color(0.8f, 0.8f, 0.8f, 1);
+        informationPackageListItemsColor1 = new Color(1, 1, 1, 1);
     }
 
     void Awake()
@@ -107,9 +114,9 @@ public class NotificationBar : MonoBehaviour, IPointerClickHandler
             informationPackage = GameManager.Instance.informationPackage;
             for (int i = 0; i < informationPackage.Count; i += 2)
             {
-                int a = i;
                 GameObject temp = GameObject.Instantiate(informationPackageItem);
                 temp.transform.SetParent(informationSpawn, false);
+                temp.GetComponent<Image>().color = (i % 4 == 0) ? informationPackageListItemsColor1 : informationPackageListItemsColor2;
                 temp.transform.GetChild(0).GetComponent<Text>().text = informationPackage[i];
                 temp.transform.GetChild(1).GetComponent<Text>().text = informationPackage[i + 1];
                 temp.GetComponent<Button>().onClick.AddListener(delegate ()


### PR DESCRIPTION
**InformationPackagemanager**
- Validation of information package no longer gives duplicate minus scores when iterating a list even after finding that it was a match. The bug resulted in much more minus points than plus points. 
- You now get minus points for each information package you lack in comparison to tasks
- Validation of informationpackage now uses the correct variable which holds the information package in gamemanager (the old one was allways null, after the recent changes to objectives). 
- AddScore is now only called tvice instead of multiple (n^5) times in informationpackagemanager.


**Objectives**
- Set objectives in AppSettingsScene and Day2 to be equal (They need to be set on Day2 to work if you click newGame in endscene.)
- Emptied objectives in Day1 scene (not used).
- Set objectives on day 1 in story to find all your friends' name. 
- Set objectives on day 2 in story to find adress to Tom and Trine and a post your mother posted on her birthday.

**Known issues**:
- The post on mother objective day 2 doesnt work, regardless of methods attempted to do string comparison. They have the same lenght, and after trimming, trailing, cutting whitespace, checking encoding, removing line breaks and newlines, replacing newlines and linebreaks, I decided to push this request regardless, after spending 4 hours banging my head to a wall trying to figure out why a single string comparison allways fail.
- Some debugging code is still left, if anyone wanna have a go at the issue. 